### PR TITLE
Amended to README.md dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ addEventListener(Event.ENTER_FRAME, function(e)
 
 ## Dependencies
 
-* Kinect for Windows SDK http://www.microsoft.com/en-us/kinectforwindowsdev/Downloads.aspx
+* Kinect for Windows SDK & Kinect for Windows Developer Toolkit http://www.microsoft.com/en-us/kinectforwindowsdev/Downloads.aspx
 * Haxe and OpenFL http://www.openfl.org/documentation/setup/install-haxe/
-* Visual Studio 2012 / Visual Studio 2012 Express (2010 Will not compile ) http://www.microsoft.com/en-us/download/details.aspx?id=34673
+* Visual Studio 2012 / Visual Studio 2012 Express (2010 Will not compile) http://www.microsoft.com/en-us/download/details.aspx?id=34673
 
 ## Depth Stream
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ addEventListener(Event.ENTER_FRAME, function(e)
 
 * Kinect for Windows SDK http://www.microsoft.com/en-us/kinectforwindowsdev/Downloads.aspx
 * Haxe and OpenFL http://www.openfl.org/documentation/setup/install-haxe/
+* Visual Studio 2012 / Visual Studio 2012 Express (2010 Will not compile ) http://www.microsoft.com/en-us/download/details.aspx?id=34673
 
 ## Depth Stream
 


### PR DESCRIPTION
I have added two dependencies to README.md which should help people avoid a few problems I had when compiling the ndll.

I only had Visual Studio 2010 express installed which caused the compilation to fail. with this message:
"Cannot open include file: 'thread': No such file or directory". Stack overflow suggested upgrading to 2012 which fixed it: http://stackoverflow.com/questions/18367147/cannot-open-include-file-thread

I initially only installed the Windows SDK and not the developer toolkit which has the dll and some other includes.
